### PR TITLE
Automatically create wrapper when appOptions.el is provided. Resolves #33

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -18,11 +18,18 @@ export default function singleSpaVue(userOpts) {
   };
 
   if (!opts.Vue) {
-    throw new Error("single-spa-vuejs must be passed opts.Vue");
+    throw Error("single-spa-vue must be passed opts.Vue");
   }
 
   if (!opts.appOptions) {
-    throw new Error("single-spa-vuejs must be passed opts.appOptions");
+    throw Error("single-spa-vue must be passed opts.appOptions");
+  }
+
+  if (opts.appOptions.el && typeof opts.appOptions.el !== "string") {
+    throw Error(
+      `single-spa-vue: appOptions.el must be a string CSS selector, or not provided at all. Was given ${typeof opts
+        .appOptions.el}`
+    );
   }
 
   // Just a shared object to store the mounted object state

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -51,27 +51,37 @@ function mount(opts, mountedInstances, props) {
       appOptions.el = props.domElement;
     }
 
-    if (!appOptions.el) {
+    let domEl;
+    if (appOptions.el) {
+      domEl = document.querySelector(appOptions.el);
+      if (!domEl) {
+        throw Error(
+          `If appOptions.el is provided to single-spa-vue, the dom element must exist in the dom. Was provided as ${appOptions.el}`
+        );
+      }
+    } else {
       const htmlId = `single-spa-application:${props.name}`;
-      appOptions.el = `#${CSS.escape(htmlId)} .single-spa-container`;
-      let domEl = document.getElementById(htmlId);
+      appOptions.el = `#${CSS.escape(htmlId)}`;
+      domEl = document.getElementById(htmlId);
       if (!domEl) {
         domEl = document.createElement("div");
         domEl.id = htmlId;
         document.body.appendChild(domEl);
       }
-
-      // single-spa-vue@>=2 always REPLACES the `el` instead of appending to it.
-      // We want domEl to stick around and not be replaced. So we tell Vue to mount
-      // into a container div inside of the main domEl
-      if (!domEl.querySelector(".single-spa-container")) {
-        const singleSpaContainer = document.createElement("div");
-        singleSpaContainer.className = "single-spa-container";
-        domEl.appendChild(singleSpaContainer);
-      }
-
-      mountedInstances.domEl = domEl;
     }
+
+    appOptions.el = appOptions.el + " .single-spa-container";
+
+    // single-spa-vue@>=2 always REPLACES the `el` instead of appending to it.
+    // We want domEl to stick around and not be replaced. So we tell Vue to mount
+    // into a container div inside of the main domEl
+    if (!domEl.querySelector(".single-spa-container")) {
+      const singleSpaContainer = document.createElement("div");
+      singleSpaContainer.className = "single-spa-container";
+      domEl.appendChild(singleSpaContainer);
+    }
+
+    mountedInstances.domEl = domEl;
 
     if (!appOptions.render && !appOptions.template && opts.rootComponent) {
       appOptions.render = h => h(opts.rootComponent);

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -25,9 +25,13 @@ export default function singleSpaVue(userOpts) {
     throw Error("single-spa-vue must be passed opts.appOptions");
   }
 
-  if (opts.appOptions.el && typeof opts.appOptions.el !== "string") {
+  if (
+    opts.appOptions.el &&
+    typeof opts.appOptions.el !== "string" &&
+    !(opts.appOptions.el instanceof HTMLElement)
+  ) {
     throw Error(
-      `single-spa-vue: appOptions.el must be a string CSS selector, or not provided at all. Was given ${typeof opts
+      `single-spa-vue: appOptions.el must be a string CSS selector, an HTMLElement, or not provided at all. Was given ${typeof opts
         .appOptions.el}`
     );
   }
@@ -60,11 +64,15 @@ function mount(opts, mountedInstances, props) {
 
     let domEl;
     if (appOptions.el) {
-      domEl = document.querySelector(appOptions.el);
-      if (!domEl) {
-        throw Error(
-          `If appOptions.el is provided to single-spa-vue, the dom element must exist in the dom. Was provided as ${appOptions.el}`
-        );
+      if (typeof appOptions.el === "string") {
+        domEl = document.querySelector(appOptions.el);
+        if (!domEl) {
+          throw Error(
+            `If appOptions.el is provided to single-spa-vue, the dom element must exist in the dom. Was provided as ${appOptions.el}`
+          );
+        }
+      } else {
+        domEl = appOptions.el;
       }
     } else {
       const htmlId = `single-spa-application:${props.name}`;

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -64,6 +64,34 @@ describe("single-spa-vue", () => {
       });
   });
 
+  it(`uses the appOptions.el selector if provided, and wraps the single-spa application in a container div`, () => {
+    document.body.appendChild(
+      Object.assign(document.createElement("div"), {
+        id: "my-custom-el"
+      })
+    );
+
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {
+        el: "#my-custom-el"
+      }
+    });
+
+    expect(document.querySelector(`#my-custom-el .single-spa-container`)).toBe(
+      null
+    );
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        expect(
+          document.querySelector(`#my-custom-el .single-spa-container`)
+        ).toBeTruthy();
+      });
+  });
+
   it(`reuses the default dom element container on the second mount`, () => {
     const lifecycles = new singleSpaVue({
       Vue,
@@ -96,7 +124,6 @@ describe("single-spa-vue", () => {
 
   it(`passes appOptions straight through to Vue`, () => {
     const appOptions = {
-      el: document.createElement("div"),
       something: "random"
     };
     const lifecycles = new singleSpaVue({
@@ -109,7 +136,6 @@ describe("single-spa-vue", () => {
       .then(() => lifecycles.mount(props))
       .then(() => {
         expect(Vue).toHaveBeenCalled();
-        expect(Vue.mock.calls[0][0].el).toBeTruthy();
         expect(Vue.mock.calls[0][0].something).toBeTruthy();
         return lifecycles.unmount(props);
       });

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -89,6 +89,39 @@ describe("single-spa-vue", () => {
         expect(
           document.querySelector(`#my-custom-el .single-spa-container`)
         ).toBeTruthy();
+
+        document.querySelector("#my-custom-el").remove();
+      });
+  });
+
+  it(`throws an error if appOptions.el is not passed in as a string`, () => {
+    expect(() => {
+      new singleSpaVue({
+        Vue,
+        appOptions: {
+          // `el` should be a string
+          el: document.createElement("div")
+        }
+      });
+    }).toThrow(/must be a string CSS selector/);
+  });
+
+  it(`throws an error if appOptions.el doesn't exist in the dom`, () => {
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {
+        el: "#doesnt-exist-in-dom"
+      }
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        fail("should throw validation error");
+      })
+      .catch(err => {
+        expect(err.message).toMatch("the dom element must exist in the dom");
       });
   });
 

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -64,7 +64,7 @@ describe("single-spa-vue", () => {
       });
   });
 
-  it(`uses the appOptions.el selector if provided, and wraps the single-spa application in a container div`, () => {
+  it(`uses the appOptions.el selector string if provided, and wraps the single-spa application in a container div`, () => {
     document.body.appendChild(
       Object.assign(document.createElement("div"), {
         id: "my-custom-el"
@@ -94,13 +94,42 @@ describe("single-spa-vue", () => {
       });
   });
 
-  it(`throws an error if appOptions.el is not passed in as a string`, () => {
+  it(`uses the appOptions.el domElement if provided, and wraps the single-spa application in a container div`, () => {
+    const domEl = Object.assign(document.createElement("div"), {
+      id: "my-custom-el-2"
+    });
+
+    document.body.appendChild(domEl);
+
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {
+        el: domEl
+      }
+    });
+
+    expect(
+      document.querySelector(`#my-custom-el-2 .single-spa-container`)
+    ).toBe(null);
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        expect(
+          document.querySelector(`#my-custom-el-2 .single-spa-container`)
+        ).toBeTruthy();
+        domEl.remove();
+      });
+  });
+
+  it(`throws an error if appOptions.el is not passed in as a string or dom element`, () => {
     expect(() => {
       new singleSpaVue({
         Vue,
         appOptions: {
-          // `el` should be a string
-          el: document.createElement("div")
+          // `el` should be a string or DOM Element
+          el: 1233
         }
       });
     }).toThrow(/must be a string CSS selector/);


### PR DESCRIPTION
See #33. This ensures that the element that gets replaced by Vue is always a `single-spa-container` div, instead of the original `appOptions.el` that was passed in. Note that we were already doing this when `appOptions.el` was omitted, but now we're handling it when appOptions.el is provided.

@EvanBurbidge @maurer2 @madeofsun @jualoppaz @karladler feel free to jump in on the review for this.