### PR TITLE
attach and detach vue instance to vue devtools

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -121,6 +121,12 @@ function mount(opts, mountedInstances, props) {
 
     mountedInstances[props.name] = instance;
 
+    // attach Vue instance to the vue devtools
+    if (window.__VUE_DEVTOOLS_GLOBAL_HOOK__) {
+      window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue =
+        instance.vueInstance.constructor;
+    }
+    
     return instance.vueInstance;
   });
 }
@@ -145,6 +151,11 @@ function unmount(opts, mountedInstances, props) {
     instance.vueInstance.$el.innerHTML = "";
     delete instance.vueInstance;
 
+    // detach Vue instance to the vue devtools
+    if (window.__VUE_DEVTOOLS_GLOBAL_HOOK__) {
+      window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue = null;
+    }
+    
     if (instance.domEl) {
       instance.domEl.innerHTML = "";
       delete instance.domEl;

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -123,8 +123,7 @@ function mount(opts, mountedInstances, props) {
 
     // attach Vue instance to the vue devtools
     if (window.__VUE_DEVTOOLS_GLOBAL_HOOK__) {
-      window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue =
-        instance.vueInstance.constructor;
+      window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue = opts.Vue;
     }
 
     return instance.vueInstance;

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -126,7 +126,7 @@ function mount(opts, mountedInstances, props) {
       window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue =
         instance.vueInstance.constructor;
     }
-    
+
     return instance.vueInstance;
   });
 }
@@ -155,7 +155,7 @@ function unmount(opts, mountedInstances, props) {
     if (window.__VUE_DEVTOOLS_GLOBAL_HOOK__) {
       window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue = null;
     }
-    
+
     if (instance.domEl) {
       instance.domEl.innerHTML = "";
       delete instance.domEl;


### PR DESCRIPTION
# Description
This allows vue devtools to detect the correct Vue instance.

Fixes # (https://github.com/single-spa/single-spa-vue/issues/45)

# How Has This Been Tested?
Just using the provided test suite.

# Further notes
Note that users have to update to the latest vue devtools extension [see https://github.com/vuejs/vue-devtools/issues/874](https://github.com/vuejs/vue-devtools/issues/874).

To effectively activate devtools for dev purposes, you also have to set the following on application/microfrontend base:

Before you create app, usually in main.js **and** in your store/index.js if there's any
`Vue.config.devtools = process.env.NODE_ENV === 'development'`
