### PR TITLE
Add an api exposes Vue instance to allow users to do additional things

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -7,7 +7,8 @@ const defaultOpts = {
 
   // sometimes require opts
   Vue: null,
-  createApp: null
+  createApp: null,
+  handleInstance: null
 };
 
 export default function singleSpaVue(userOpts) {
@@ -121,6 +122,9 @@ function mount(opts, mountedInstances, props) {
 
     if (opts.createApp) {
       instance.vueInstance = opts.createApp(appOptions);
+      if (opts.handleInstance) {
+        opts.handleInstance(instance.vueInstance);
+      }
       instance.vueInstance.mount(appOptions.el);
     } else {
       instance.vueInstance = new opts.Vue(appOptions);

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -131,6 +131,9 @@ function mount(opts, mountedInstances, props) {
       if (instance.vueInstance.bind) {
         instance.vueInstance = instance.vueInstance.bind(instance.vueInstance);
       }
+      if (opts.handleInstance) {
+        opts.handleInstance(instance.vueInstance);
+      }
     }
 
     mountedInstances[props.name] = instance;

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -26,20 +26,25 @@ describe("single-spa-vue", () => {
   });
 
   it(`calls new Vue() during mount and mountedInstances.instance.$destroy() on unmount`, () => {
+    const handleInstance = jest.fn();
+
     const lifecycles = new singleSpaVue({
       Vue,
-      appOptions: {}
+      appOptions: {},
+      handleInstance
     });
 
     return lifecycles
       .bootstrap(props)
       .then(() => {
         expect(Vue).not.toHaveBeenCalled();
+        expect(handleInstance).not.toHaveBeenCalled();
         expect($destroy).not.toHaveBeenCalled();
         return lifecycles.mount(props);
       })
       .then(() => {
         expect(Vue).toHaveBeenCalled();
+        expect(handleInstance).toHaveBeenCalled();
         expect($destroy).not.toHaveBeenCalled();
         return lifecycles.unmount(props);
       })

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -392,9 +392,12 @@ describe("single-spa-vue", () => {
 
     const props = { name: "vue3-app" };
 
+    const handleInstance = jest.fn();
+
     const lifecycles = new singleSpaVue({
       Vue,
-      appOptions: {}
+      appOptions: {},
+      handleInstance
     });
 
     await lifecycles.bootstrap(props);
@@ -403,6 +406,7 @@ describe("single-spa-vue", () => {
     expect(Vue.createApp).toHaveBeenCalled();
     // Vue 3 requires the data to be a function
     expect(typeof Vue.createApp.mock.calls[0][0].data).toBe("function");
+    expect(handleInstance).toHaveBeenCalledWith(appMock);
     expect(appMock.mount).toHaveBeenCalled();
 
     await lifecycles.unmount(props);
@@ -422,9 +426,12 @@ describe("single-spa-vue", () => {
 
     const props = { name: "vue3-app" };
 
+    const handleInstance = jest.fn();
+
     const lifecycles = new singleSpaVue({
       createApp,
-      appOptions: {}
+      appOptions: {},
+      handleInstance
     });
 
     await lifecycles.bootstrap(props);
@@ -433,6 +440,7 @@ describe("single-spa-vue", () => {
     expect(createApp).toHaveBeenCalled();
     // Vue 3 requires the data to be a function
     expect(typeof createApp.mock.calls[0][0].data).toBe("function");
+    expect(handleInstance).toHaveBeenCalledWith(appMock);
     expect(appMock.mount).toHaveBeenCalled();
 
     await lifecycles.unmount(props);


### PR DESCRIPTION
Vue 3 brings [new instance API](https://v3.vuejs.org/guide/migration/global-api.html#a-new-global-api-createapp). Vue users should register their plugins ([`vue-router`](https://next.router.vuejs.org/guide/#javascript), etc) after the instance being initialized using `createApp`, and before `mount` into dom.

This pr provides a new api called `handleInstance` hooked into this lifecycle, and exposes the initialized Vue instance to user.

Resolves #58 