### PR TITLE
Allow appOptions to resolve asynchronously

### DIFF
--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -250,6 +250,27 @@ describe("single-spa-vue", () => {
       });
   });
 
+  it(`resolves appOptions from Promise and passes straight through to Vue`, () => {
+    const appOptions = () =>
+      Promise.resolve({
+        something: "random",
+      });
+
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions,
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        expect(Vue).toHaveBeenCalled();
+        expect(Vue.mock.calls[0][0].something).toBeTruthy();
+        return lifecycles.unmount(props);
+      });
+  });
+
   it(`implements a render function for you if you provide loadRootComponent`, () => {
     const opts = {
       Vue,

--- a/types/single-spa-vue.d.ts
+++ b/types/single-spa-vue.d.ts
@@ -10,7 +10,7 @@ declare module "single-spa-vue" {
   };
 
   interface BaseSingleSpaVueOptions {
-    appOptions: AppOptions;
+    appOptions: AppOptions | (() => Promise<AppOptions>);
     template?: string;
     loadRootComponent?(): Promise<any>;
   }


### PR DESCRIPTION
**What:** This PR adds the ability to resolve app options asynchronously.
**Why:** In some scenarios (e.g. multi-tenant applications) resolution of app options such as a router, i18n etc, requires loading configuration and resources asynchronously.

At the moment there are no asynchronous hooks except `loadRootComponent` which is insufficient. 

Example:
```js

const vueLifecycles = singleSpaVue({
  Vue,
  async appOptions () {
    const config = await loadConfiguration()

    const i18n = await  i18nFactory(config);
    const router = await  routerFactory(config);

    return {
      render: h => h(App),
      router,
      i18n
    }
  }
});

export const bootstrap = vueLifecycles.bootstrap;
export const mount = vueLifecycles.mount;
export const unmount = vueLifecycles.unmount;

```
