### PR TITLE
Add replaceMode onto User Options

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -104,7 +104,6 @@ function mount(opts, mountedInstances, props) {
         }
       }
 
-     
       if (!opts.replaceMode) {
         appOptions.el = appOptions.el + " .single-spa-container";
       }

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -104,7 +104,10 @@ function mount(opts, mountedInstances, props) {
         }
       }
 
-      appOptions.el = appOptions.el + " .single-spa-container";
+     
+      if (!opts.replaceMode) {
+        appOptions.el = appOptions.el + " .single-spa-container";
+      }
 
       // single-spa-vue@>=2 always REPLACES the `el` instead of appending to it.
       // We want domEl to stick around and not be replaced. So we tell Vue to mount

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -472,4 +472,55 @@ describe("single-spa-vue", () => {
     await lifecycles.unmount(props);
     expect(appMock.unmount).toHaveBeenCalled();
   });
+
+  it(`mounts a Vue instance in specified element, if replaceMode is true`, () => {
+    const domEl = document.createElement("div");
+    const htmlId = CSS.escape("single-spa-application:test-app");
+
+    document.body.appendChild(domEl);
+
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {
+        el: domEl,
+      },
+      replaceMode: true,
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => expect(Vue.mock.calls[0][0].el).toBe(`#${htmlId}`))
+      .then(() => {
+        expect(document.querySelector(`#${htmlId}`)).toBeTruthy();
+        domEl.remove();
+      });
+  });
+
+  it(`mounts a Vue instance with ' .single-spa-container' if replaceMode is false or not provided`, () => {
+    const domEl = document.createElement("div");
+    const htmlId = CSS.escape("single-spa-application:test-app");
+
+    document.body.appendChild(domEl);
+
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {
+        el: domEl,
+      },
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() =>
+        expect(Vue.mock.calls[0][0].el).toBe(`#${htmlId} .single-spa-container`)
+      )
+      .then(() => {
+        expect(
+          document.querySelector(`#${htmlId} .single-spa-container`)
+        ).toBeTruthy();
+        domEl.remove();
+      });
+  });
 });


### PR DESCRIPTION
This PR is related to #64 discussion, and it is a pretty naive implementation of what I understand would suffice to allow users to mount their applications onto the specified DOM element, and avoid the concatenation of `.single-spa-container` class.