### PR TITLE
Pass the props to the `appOptions` and `handleInstance` functions.

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -132,7 +132,7 @@ function mount(opts, mountedInstances, props) {
       if (opts.createApp) {
         instance.vueInstance = opts.createApp(appOptions);
         if (opts.handleInstance) {
-          opts.handleInstance(instance.vueInstance);
+          opts.handleInstance(instance.vueInstance, props);
         }
         instance.vueInstance.mount(appOptions.el);
       } else {
@@ -143,7 +143,7 @@ function mount(opts, mountedInstances, props) {
           );
         }
         if (opts.handleInstance) {
-          opts.handleInstance(instance.vueInstance);
+          opts.handleInstance(instance.vueInstance, props);
         }
       }
 

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -62,9 +62,9 @@ function bootstrap(opts) {
   }
 }
 
-function resolveAppOptions(opts) {
+function resolveAppOptions(opts, props) {
   if (typeof opts.appOptions === "function") {
-    return opts.appOptions();
+    return opts.appOptions(props);
   }
   return Promise.resolve({ ...opts.appOptions });
 }
@@ -72,7 +72,7 @@ function resolveAppOptions(opts) {
 function mount(opts, mountedInstances, props) {
   const instance = {};
   return Promise.resolve().then(() => {
-    return resolveAppOptions(opts).then((appOptions) => {
+    return resolveAppOptions(opts, props).then((appOptions) => {
       if (props.domElement && !appOptions.el) {
         appOptions.el = props.domElement;
       }

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -271,6 +271,27 @@ describe("single-spa-vue", () => {
       });
   });
 
+  it(`appOptions function will recieve the props provided at mount`, () => {
+    const appOptions = jest.fn((props) =>
+      Promise.resolve({
+        props,
+      })
+    );
+
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions,
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        expect(appOptions.mock.calls[0][0]).toBe(props);
+        return lifecycles.unmount(props);
+      });
+  });
+
   it(`implements a render function for you if you provide loadRootComponent`, () => {
     const opts = {
       Vue,

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -292,6 +292,23 @@ describe("single-spa-vue", () => {
       });
   });
 
+  it("`handleInstance` function will recieve the props provided at mount", () => {
+    const handleInstance = jest.fn();
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {},
+      handleInstance,
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        expect(handleInstance.mock.calls[0][1]).toBe(props);
+        return lifecycles.unmount(props);
+      });
+  });
+
   it(`implements a render function for you if you provide loadRootComponent`, () => {
     const opts = {
       Vue,
@@ -453,7 +470,7 @@ describe("single-spa-vue", () => {
     expect(Vue.createApp).toHaveBeenCalled();
     // Vue 3 requires the data to be a function
     expect(typeof Vue.createApp.mock.calls[0][0].data).toBe("function");
-    expect(handleInstance).toHaveBeenCalledWith(appMock);
+    expect(handleInstance).toHaveBeenCalledWith(appMock, props);
     expect(appMock.mount).toHaveBeenCalled();
 
     await lifecycles.unmount(props);
@@ -487,7 +504,7 @@ describe("single-spa-vue", () => {
     expect(createApp).toHaveBeenCalled();
     // Vue 3 requires the data to be a function
     expect(typeof createApp.mock.calls[0][0].data).toBe("function");
-    expect(handleInstance).toHaveBeenCalledWith(appMock);
+    expect(handleInstance).toHaveBeenCalledWith(appMock, props);
     expect(appMock.mount).toHaveBeenCalled();
 
     await lifecycles.unmount(props);

--- a/types/single-spa-vue.d.ts
+++ b/types/single-spa-vue.d.ts
@@ -10,7 +10,7 @@ declare module "single-spa-vue" {
   };
 
   interface BaseSingleSpaVueOptions {
-    appOptions: AppOptions | (() => Promise<AppOptions>);
+    appOptions: AppOptions | ((props?: object) => Promise<AppOptions>);
     template?: string;
     loadRootComponent?(): Promise<any>;
   }


### PR DESCRIPTION
I found I need access to the props when setting up the application and the Vue instance. I know these are passed into the application instance as data, however that means I can only access the props in the application instance. Furthermore, sometimes some of the props don't need to be in the application instance or some of the props may be objects with behavior of which I give to my Vuex modules.

This change enables the following:
``` js
const lifeCycle = singleSpaVue({
    async appOptions (props)
    {
        // can now access the props.
    },
    handleInstance (instance, props)
    {
        // can now access the props.
    }
});
```