### PR TITLE
Fixed the update lifecycle method to support Vue 3.

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -134,7 +134,7 @@ function mount(opts, mountedInstances, props) {
         if (opts.handleInstance) {
           opts.handleInstance(instance.vueInstance);
         }
-        instance.vueInstance.mount(appOptions.el);
+        instance.root = instance.vueInstance.mount(appOptions.el);
       } else {
         instance.vueInstance = new opts.Vue(appOptions);
         if (instance.vueInstance.bind) {
@@ -161,8 +161,9 @@ function update(opts, mountedInstances, props) {
       ...(opts.appOptions.data || {}),
       ...props,
     };
+    const root = instance.root || instance.vueInstance;
     for (let prop in data) {
-      instance.vueInstance[prop] = data[prop];
+      root[prop] = data[prop];
     }
   });
 }


### PR DESCRIPTION
**Problem**

The `update` lifecycle method doesn't work in Vue 3.

**Explanation** 

With Vue 2 you create an application like so:
``` js
const app = new Vue({
    // ...
});
```
With this instance you can mount it and update its props like so:
``` js
app.mount('#element');

app['prop'] = 'value';
```
In Vue 3, this has changed. You still create an application, like so:
``` js
const app = createApp({
    // ...
});
```
However, when you mount an application you will get a reference to the root component, which is what you use to update reactive data after the fact:
``` js
const root = app.mount('#element');

root['prop'] = 'value';
```

**Question:** I'm not really sure how to create an automation test for this as the test suite uses Vue 2.x.x. When this is a Vue 3.x.x problem.