### PR TITLE
feat: allow promise in handleInstance hook

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -132,9 +132,15 @@ function mount(opts, mountedInstances, props) {
       if (opts.createApp) {
         instance.vueInstance = opts.createApp(appOptions);
         if (opts.handleInstance) {
-          opts.handleInstance(instance.vueInstance, props);
+          return Promise.resolve(
+            opts.handleInstance(instance.vueInstance, props)
+          ).then(function () {
+            instance.root = instance.vueInstance.mount(appOptions.el);
+            mountedInstances[props.name] = instance;
+
+            return instance.vueInstance;
+          });
         }
-        instance.root = instance.vueInstance.mount(appOptions.el);
       } else {
         instance.vueInstance = new opts.Vue(appOptions);
         if (instance.vueInstance.bind) {
@@ -143,7 +149,12 @@ function mount(opts, mountedInstances, props) {
           );
         }
         if (opts.handleInstance) {
-          opts.handleInstance(instance.vueInstance, props);
+          return Promise.resolve(
+            opts.handleInstance(instance.vueInstance, props)
+          ).then(function () {
+            mountedInstances[props.name] = instance;
+            return instance.vueInstance;
+          });
         }
       }
 

--- a/types/single-spa-vue.d.ts
+++ b/types/single-spa-vue.d.ts
@@ -25,8 +25,9 @@ declare module "single-spa-vue" {
   };
 
   type SingleSpaOptsVue3 = BaseSingleSpaVueOptions & {
-    createApp: any;
-    handleInstance?(instance: any, props: object): void;
+    createApp(appOptions: AppOptions): any;
+    handleInstance?(instance: any, props: object): void | Promise<void>;
+    replaceMode?: boolean;
   };
 
   type SingleSpaVueOpts = SingleSpaOptsVue2 | SingleSpaOptsVue3;


### PR DESCRIPTION
usage:
```js
  handleInstance: async (app) => {
    app.use(router);
    await router.isReady();
  }
```

resolves: https://github.com/single-spa/single-spa-vue/issues/83

refs: https://ssr.vuejs.org/guide/routing.html#code-splitting

![image](https://user-images.githubusercontent.com/1360552/126671713-0e128a52-cc5f-4f75-9565-8623efe66430.png)
