### PR TITLE
fix: mount vue3 instance if no handleInstance is provided

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -140,6 +140,8 @@ function mount(opts, mountedInstances, props) {
 
             return instance.vueInstance;
           });
+        } else {
+          instance.root = instance.vueInstance.mount(appOptions.el);
         }
       } else {
         instance.vueInstance = new opts.Vue(appOptions);


### PR DESCRIPTION
Hi,
#84 introduced a breaking Problem for Vue3 MFEs.

The if Statement was wrapped around the full Statement and didn't apply `instance.root = instance.vueInstance.mount(appOptions.el);` if handleInstance is not present. So MFEs based on Vue3 without handleInstance using single-spa-vue@2.5.0 always broke.
They would load and populate the dom initially but the vue instance would never be executed correctly.

I noticed that because newly created vue3 MFEs just didn't work. They would start and the Browser wouldn't show any Errors but the page would stay empty.