### PR TITLE
fix: merge appOptions.data and mount props error

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -127,7 +127,11 @@ function mount(opts, mountedInstances, props) {
         appOptions.data = {};
       }
 
-      appOptions.data = () => ({ ...appOptions.data, ...props });
+      const originData = appOptions.data;
+      appOptions.data = function() {
+        const data = typeof originData === "function" ? originData.call(this, this) : originData;
+        return {...data, ...props};
+      };
 
       if (opts.createApp) {
         instance.vueInstance = opts.createApp(appOptions);


### PR DESCRIPTION
```js
appOptions.data = ()=> ({...appOptions.data, ...props});
```

When merge appOptions.data and mount props，`...appOptions.data` is always a function, not an object.