### PR TITLE
Check parcel status before calling unmount

### DIFF
--- a/src/parcel.js
+++ b/src/parcel.js
@@ -38,7 +38,7 @@ export default {
 
       this.nextThingToDo = (this.nextThingToDo || Promise.resolve())
         .then((...args) => {
-          if (this.unmounted && action === "unmount") {
+          if (this.unmounted) {
             return;
           }
 

--- a/src/parcel.js
+++ b/src/parcel.js
@@ -38,7 +38,7 @@ export default {
 
       this.nextThingToDo = (this.nextThingToDo || Promise.resolve())
         .then((...args) => {
-          if (this.unmounted && action !== 'unmount') {
+          if (this.unmounted && action !== "unmount") {
             return;
           }
 
@@ -65,7 +65,7 @@ export default {
       });
     },
     singleSpaUnmount() {
-      if (this.parcel && this.parcel.getStatus() === 'MOUNTED') {
+      if (this.parcel && this.parcel.getStatus() === "MOUNTED") {
         return this.parcel.unmount();
       }
     },

--- a/src/parcel.js
+++ b/src/parcel.js
@@ -38,7 +38,7 @@ export default {
 
       this.nextThingToDo = (this.nextThingToDo || Promise.resolve())
         .then((...args) => {
-          if (this.unmounted) {
+          if (this.unmounted && action !== 'unmount') {
             return;
           }
 
@@ -65,7 +65,7 @@ export default {
       });
     },
     singleSpaUnmount() {
-      if (this.parcel) {
+      if (this.parcel && this.parcel.getStatus() === 'MOUNTED') {
         return this.parcel.unmount();
       }
     },

--- a/src/parcel.js
+++ b/src/parcel.js
@@ -38,7 +38,7 @@ export default {
 
       this.nextThingToDo = (this.nextThingToDo || Promise.resolve())
         .then((...args) => {
-          if (this.unmounted && action !== "unmount") {
+          if (this.unmounted && action === "unmount") {
             return;
           }
 


### PR DESCRIPTION
I have been running into the following error using the Parcel component:
![image](https://user-images.githubusercontent.com/65285334/156581694-8789b62f-f207-47ec-a9f9-4ede3fbf8a3f.png)

This occurs when the parent application unmounts. Looking at the lib, there's no check on the parcel status before calling `unmount`. 

My change is the equivalent of this line in single-spa-react:
https://github.com/single-spa/single-spa-react/blob/main/src/parcel.js#L66

Ensuring that `unmount` is only ever called on parcels with a status of `MOUNTED`.

I would be grateful if someone more familiar with the project could please review this, hoping it's suitable to merge!