### PR TITLE
refactor: replace string selectors with HTMLElements for single-spa mount

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -88,24 +88,23 @@ function mount(opts, mountedInstances, props) {
           }
         } else {
           domEl = appOptions.el;
+          if (!domEl.parentNode) {
+            throw Error(
+              `If appOptions.el is provided to single-spa-vue, the dom element must exist in the dom. Was provided as ${appOptions.el.outerHTML}`
+            );
+          }
           if (!domEl.id) {
             domEl.id = `single-spa-application:${props.name}`;
           }
-          appOptions.el = `#${CSS.escape(domEl.id)}`;
         }
       } else {
         const htmlId = `single-spa-application:${props.name}`;
-        appOptions.el = `#${CSS.escape(htmlId)}`;
         domEl = document.getElementById(htmlId);
         if (!domEl) {
           domEl = document.createElement("div");
           domEl.id = htmlId;
           document.body.appendChild(domEl);
         }
-      }
-
-      if (!opts.replaceMode) {
-        appOptions.el = appOptions.el + " .single-spa-container";
       }
 
       // single-spa-vue@>=2 always REPLACES the `el` instead of appending to it.
@@ -118,6 +117,12 @@ function mount(opts, mountedInstances, props) {
       }
 
       instance.domEl = domEl;
+
+      if (!opts.replaceMode) {
+        domEl = domEl.querySelector(".single-spa-container");
+      }
+
+      appOptions.el = domEl;
 
       if (!appOptions.render && !appOptions.template && opts.rootComponent) {
         appOptions.render = (h) => h(opts.rootComponent);

--- a/src/single-spa-vue.test.js
+++ b/src/single-spa-vue.test.js
@@ -3,6 +3,13 @@ import singleSpaVue from "./single-spa-vue";
 const domElId = `single-spa-application:test-app`;
 const cssSelector = `#single-spa-application\\:test-app`;
 
+const singleSpaContainerDiv = document.createElement("div");
+singleSpaContainerDiv.className = "single-spa-container";
+
+const singleSpaApplicationDiv = document.createElement("div");
+singleSpaApplicationDiv.id = domElId;
+singleSpaApplicationDiv.append(singleSpaContainerDiv);
+
 describe("single-spa-vue", () => {
   let Vue, props, $destroy;
 
@@ -122,9 +129,7 @@ describe("single-spa-vue", () => {
       .then(() => lifecycles.mount(props))
       .then(() => {
         expect(Vue).toHaveBeenCalled();
-        expect(Vue.mock.calls[0][0].el).toBe(
-          "#my-custom-el-2 .single-spa-container"
-        );
+        expect(Vue.mock.calls[0][0].el).toEqual(singleSpaContainerDiv);
         expect(Vue.mock.calls[0][0].data()).toEqual({
           name: "test-app",
         });
@@ -155,9 +160,7 @@ describe("single-spa-vue", () => {
       .bootstrap(props)
       .then(() => lifecycles.mount(props))
       .then(() => {
-        expect(Vue.mock.calls[0][0].el).toBe(
-          `#${htmlId} .single-spa-container`
-        );
+        expect(Vue.mock.calls[0][0].el).toEqual(singleSpaContainerDiv);
         expect(Vue.mock.calls[0][0].data()).toEqual({
           name: "test-app",
         });
@@ -182,11 +185,31 @@ describe("single-spa-vue", () => {
     }).toThrow(/must be a string CSS selector/);
   });
 
-  it(`throws an error if appOptions.el doesn't exist in the dom`, () => {
+  it(`throws an error if appOptions.el as string selector doesn't exist in the dom`, () => {
     const lifecycles = new singleSpaVue({
       Vue,
       appOptions: {
         el: "#doesnt-exist-in-dom",
+      },
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        fail("should throw validation error");
+      })
+      .catch((err) => {
+        expect(err.message).toMatch("the dom element must exist in the dom");
+      });
+  });
+
+  it(`throws an error if appOptions.el as HTMLElement doesn't exist in the dom`, () => {
+    const doesntExistInDom = document.createElement("div");
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {
+        el: doesntExistInDom,
       },
     });
 
@@ -363,9 +386,7 @@ describe("single-spa-vue", () => {
       .then(() => lifecycles.mount(props))
       .then(() => {
         expect(Vue).toHaveBeenCalled();
-        expect(Vue.mock.calls[0][0].el).toBe(
-          cssSelector + " .single-spa-container"
-        );
+        expect(Vue.mock.calls[0][0].el).toEqual(singleSpaContainerDiv);
         return lifecycles.unmount(props);
       });
   });
@@ -598,7 +619,9 @@ describe("single-spa-vue", () => {
     return lifecycles
       .bootstrap(props)
       .then(() => lifecycles.mount(props))
-      .then(() => expect(Vue.mock.calls[0][0].el).toBe(`#${htmlId}`))
+      .then(() =>
+        expect(Vue.mock.calls[0][0].el).toEqual(singleSpaApplicationDiv)
+      )
       .then(() => {
         expect(document.querySelector(`#${htmlId}`)).toBeTruthy();
         domEl.remove();
@@ -622,11 +645,43 @@ describe("single-spa-vue", () => {
       .bootstrap(props)
       .then(() => lifecycles.mount(props))
       .then(() =>
-        expect(Vue.mock.calls[0][0].el).toBe(`#${htmlId} .single-spa-container`)
+        expect(Vue.mock.calls[0][0].el).toEqual(singleSpaContainerDiv)
       )
       .then(() => {
         expect(
           document.querySelector(`#${htmlId} .single-spa-container`)
+        ).toBeTruthy();
+        domEl.remove();
+      });
+  });
+
+  it(`mounts into a shadow dom`, () => {
+    const domEl = document.createElement("div");
+    domEl.attachShadow({ mode: "open" });
+
+    const shadowMount = document.createElement("div");
+    domEl.shadowRoot.append(shadowMount);
+
+    const htmlId = CSS.escape("single-spa-application:test-app");
+
+    document.body.appendChild(domEl);
+
+    const lifecycles = new singleSpaVue({
+      Vue,
+      appOptions: {
+        el: shadowMount,
+      },
+    });
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() =>
+        expect(Vue.mock.calls[0][0].el).toEqual(singleSpaContainerDiv)
+      )
+      .then(() => {
+        expect(
+          domEl.shadowRoot.querySelector(`#${htmlId} .single-spa-container`)
         ).toBeTruthy();
         domEl.remove();
       });


### PR DESCRIPTION
**The Context**
We are currently implementing a micro-frontend architecture using single-spa, and to avoid CSS leaks, we decided to mount our micro-frontend inside a ShadowDom.
It works fine with single-spa-angular and single-spa-react, but we have an issue with single-spa-vue.

**The issue**
single-spa-vue has an option called `appOptions` where you can define an `el` parameter that allows us to define either an HTMLElement or a string selector which will be used to mount the Vue application.
However, the parameter `el` is altered by single-spa-vue to become in either case a string selector.
This string selector is used to locate the div inside the DOM to mount the Vue application, but when using a ShadowDom, it will not be able to locate the div, because it resides inside the ShadowDom.

**The solution**
Vue2 and Vue3 support having an HTMLElement for the `el` parameter. So instead of relying on string selectors, we could rely only on HTMLElements.

**Resume of the changes**
 - Rely on HTMLElement instead of string selector in the mount function for single-spa applications
 - Adapt tests to reflect those changes
 - Add a test with ShadowDom

The changes should be retro-compatible, however we tried to make it more robust.
If you give to the `el` parameter an element that has no parentNode (meaning it is not present in the DOM), an error will be thrown. Before nothing would happen.
