### PR TITLE
fix: only create single-spa-container element when not using replaceMode

### DIFF
--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -106,7 +106,7 @@ function mount(opts, mountedInstances, props) {
 
       if (!opts.replaceMode) {
         appOptions.el = appOptions.el + " .single-spa-container";
-      
+
         // single-spa-vue@>=2 always REPLACES the `el` instead of appending to it.
         // We want domEl to stick around and not be replaced. So we tell Vue to mount
         // into a container div inside of the main domEl

--- a/src/single-spa-vue.js
+++ b/src/single-spa-vue.js
@@ -106,15 +106,15 @@ function mount(opts, mountedInstances, props) {
 
       if (!opts.replaceMode) {
         appOptions.el = appOptions.el + " .single-spa-container";
-      }
-
-      // single-spa-vue@>=2 always REPLACES the `el` instead of appending to it.
-      // We want domEl to stick around and not be replaced. So we tell Vue to mount
-      // into a container div inside of the main domEl
-      if (!domEl.querySelector(".single-spa-container")) {
-        const singleSpaContainer = document.createElement("div");
-        singleSpaContainer.className = "single-spa-container";
-        domEl.appendChild(singleSpaContainer);
+      
+        // single-spa-vue@>=2 always REPLACES the `el` instead of appending to it.
+        // We want domEl to stick around and not be replaced. So we tell Vue to mount
+        // into a container div inside of the main domEl
+        if (!domEl.querySelector(".single-spa-container")) {
+          const singleSpaContainer = document.createElement("div");
+          singleSpaContainer.className = "single-spa-container";
+          domEl.appendChild(singleSpaContainer);
+        }
       }
 
       instance.domEl = domEl;


### PR DESCRIPTION
When using the `replaceMode: true` option, it is not needed to create the wrapper `div.single-spa-container` element. When using `replaceMode: true` alongside SSR, this creates a hydration mismatch, as Vue does not expect the `div.single-spa-container` element to exist.