### PR TITLE
fix(Parcel): Do not try to unmount when parcel is already unmounted

### DIFF
--- a/src/parcel.js
+++ b/src/parcel.js
@@ -65,7 +65,7 @@ export default {
       });
     },
     singleSpaUnmount() {
-      if (this.parcel) {
+      if (this.parcel && this.parcel.getStatus() === "MOUNTED") {
         return this.parcel.unmount();
       }
     },


### PR DESCRIPTION
Problem
We are currently experiencing an issue where whenever SingleSPA is unmounting the Micro-Frontend which contains a parcel we get the following [error](https://single-spa.js.org/error/?code=6&arg=sales-channels-creation&arg=NOT_MOUNTED) basically telling us that we are trying to unmount a parcel which is already unmounted.

Investigation
After some investigation we found out that the parcel component is not checking if the parcel is actually mounted b
efore unmounting it. Using log points in chrome we confirmed our suspicion that it is coming from single-spa-vue. 
![Bildschirmfoto 2024-05-21 um 17 43 26](https://github.com/single-spa/single-spa-vue/assets/11974948/9c515098-e331-40a0-b6ae-53225a07041a) 
This log is emitted right before trying to call the unmount function.

Solution
Add a check to make sure that the parcel is mounted before unmounting it. While checking the single-spa-**react** package we saw that they have implemented the same solution, most likely for the same issue, as you can see [here](https://github.com/single-spa/single-spa-react/blob/main/src/parcel.js#L66).